### PR TITLE
fix: 修正 mariadb 配置文件权限

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -514,6 +514,7 @@ function prepare_config() {
   find "${CONFIG_DIR}" -type d -exec chmod 700 {} \;
   find "${CONFIG_DIR}" -type f -exec chmod 600 {} \;
   chmod 644 "${CONFIG_DIR}/redis/redis.conf"
+  chmod 644 "${CONFIG_DIR}/mariadb/mariadb.cnf"
 
   if [[ "$(uname -m)" == "aarch64" ]]; then
     sed -i "s/# ignore-warnings ARM64-COW-BUG/ignore-warnings ARM64-COW-BUG/g" "${CONFIG_DIR}/redis/redis.conf"


### PR DESCRIPTION
mariadb:10.6 镜像使用普通用户运行 mariadbd，无法读取 mariadb 配置文件内容。

v3.10.12 版演示如下：

```
[root@OPS-JUMP01 ~]# jmsctl status
NAME         IMAGE                                   COMMAND                  SERVICE   CREATED      STATUS                PORTS
jms_celery   docker.io/jumpserver/core-ce:v3.10.12   "./entrypoint.sh sta…"   celery    6 days ago   Up 6 days (healthy)   8080/tcp
jms_chen     docker.io/jumpserver/chen:v3.10.12      "./entrypoint.sh"        chen      6 days ago   Up 6 days (healthy)   8082/tcp
jms_core     docker.io/jumpserver/core-ce:v3.10.12   "./entrypoint.sh sta…"   core      6 days ago   Up 6 days (healthy)   8080/tcp
jms_kael     docker.io/jumpserver/kael:v3.10.12      "./entrypoint.sh"        kael      6 days ago   Up 6 days (healthy)   8083/tcp
jms_koko     docker.io/jumpserver/koko:v3.10.12      "./entrypoint.sh"        koko      6 days ago   Up 6 days (healthy)   0.0.0.0:2222->2222/tcp, 5000/tcp
jms_lion     docker.io/jumpserver/lion:v3.10.12      "./entrypoint.sh"        lion      6 days ago   Up 6 days (healthy)   4822/tcp, 8081/tcp
jms_magnus   docker.io/jumpserver/magnus:v3.10.12    "./entrypoint.sh"        magnus    6 days ago   Up 6 days (healthy)   8088/tcp, 14330/tcp, 0.0.0.0:33061-33062->33061-33062/tcp, 54320/tcp, 0.0.0.0:63790->63790/tcp
jms_mysql    jumpserver/mariadb:10.6                 "docker-entrypoint.s…"   mysql     6 days ago   Up 6 days (healthy)   3306/tcp
jms_redis    jumpserver/redis:6.2                    "docker-entrypoint.s…"   redis     6 days ago   Up 6 days (healthy)   6379/tcp
jms_web      docker.io/jumpserver/web:v3.10.12       "/docker-entrypoint.…"   web       6 days ago   Up 6 days (healthy)   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp

[root@OPS-JUMP01 ~]# ls -alht /opt/jumpserver/config/mariadb/mariadb.cnf
-rw------- 1 root root 1.2K Aug  1 16:36 /opt/jumpserver/config/mariadb/mariadb.cnf

[root@OPS-JUMP01 ~]# jmsctl raw exec mysql bash
root@jms_mysql:/# ps -ef
UID         PID   PPID  C STIME TTY          TIME CMD
mysql         1      0  2 Jul31 ?        03:12:05 mariadbd --character-set-server=utf8 --collation-server=utf8_general_ci
...
root@jms_mysql:/# ls -alht /etc/mysql/mariadb.cnf
-rw------- 0 root root 1.2K Mar  7 01:44 /etc/mysql/mariadb.cnf
root@jms_mysql:/# runuser -u mysql cat /etc/mysql/mariadb.cnf
cat: /etc/mysql/mariadb.cnf: Permission denied
root@jms_mysql:/#
```