### PR TITLE
fix: Offline installer needs iptables and python to perform correctly.

### DIFF
--- a/scripts/4_install_jumpserver.sh
+++ b/scripts/4_install_jumpserver.sh
@@ -15,6 +15,20 @@ function pre_install() {
       exit 1
     }
   fi
+  if ! command -v iptables &>/dev/null; then 
+    log_error "Docker needs iptables. Please install iptables first."
+    exit 1
+  fi
+  if command -v python&>/dev/null; then
+    :
+  elif command -v python2&>/dev/null; then
+    :
+  elif command -v python3&>/dev/null; then
+    :
+  else
+    log_error "Docker compose needs python. Please install python first."
+    exit 1
+  fi
 }
 
 function post_install() {


### PR DESCRIPTION
Check iptables and python exist on target system before install docker and docker compose.