### PR TITLE
add gettext to prepare_install()

### DIFF
--- a/quick_start.sh
+++ b/quick_start.sh
@@ -25,7 +25,7 @@ function install_soft() {
 }
 
 function prepare_install() {
-  for i in curl wget tar iptables; do
+  for i in curl wget tar iptables gettext; do
     command -v $i &>/dev/null || install_soft $i
   done
 }


### PR DESCRIPTION
This PR adds `gettext` to the list of apps to check for in `prepare_install()` and install if they're missing.

I was running the quick start call on a minimal Ubuntu 24.04 server:

```
curl -sSL https://github.com/jumpserver/jumpserver/releases/latest/download/quick_start.sh | bash
```

However, I got an error during install `gettext: command not found` (see full context below). Running `apt install gettext` fixed the issue



--------------

```
Processing triggers for libc-bin (2.39-0ubuntu8.4) ...
download install script to /opt/jumpserver-installer-v4.10.1


       ██╗██╗   ██╗███╗   ███╗██████╗ ███████╗███████╗██████╗ ██╗   ██╗███████╗██████╗
       ██║██║   ██║████╗ ████║██╔══██╗██╔════╝██╔════╝██╔══██╗██║   ██║██╔════╝██╔══██╗
       ██║██║   ██║██╔████╔██║██████╔╝███████╗█████╗  ██████╔╝██║   ██║█████╗  ██████╔╝
  ██   ██║██║   ██║██║╚██╔╝██║██╔═══╝ ╚════██║██╔══╝  ██╔══██╗╚██╗ ██╔╝██╔══╝  ██╔══██╗
  ╚█████╔╝╚██████╔╝██║ ╚═╝ ██║██║     ███████║███████╗██║  ██║ ╚████╔╝ ███████╗██║  ██║
   ╚════╝  ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝

                                                                   Version:  v4.10.1-ce  

/opt/jumpserver-installer-v4.10.1/scripts/utils.sh: line 461: gettext: command not found
1. 
/opt/jumpserver-installer-v4.10.1/scripts/utils.sh: line 462: gettext: command not found
: /opt/jumpserver/config
/opt/jumpserver/config/config.txt        [ √ ]
/opt/jumpserver/config/loki/promtail.yml         [ √ ]
/opt/jumpserver/config/nginx/cert/server.crt     [ √ ]
/opt/jumpserver/config/nginx/cert/server.key     [ √ ]
/opt/jumpserver-installer-v4.10.1/scripts/4_install_jumpserver.sh: line 88: gettext: command not found

>>> 
/opt/jumpserver-installer-v4.10.1/scripts/2_install_docker.sh: line 189: gettext: command not found
1. 
/opt/jumpserver-installer-v4.10.1/scripts/utils.sh: line 429: gettext: command not found
gettext:  gettext

./jmsctl.sh: line 81: docker: command not found
root@jumpserver-test:~# gettext
```