### PR TITLE
Perf: Prevent command injection vulnerabilities in database backup/restore scripts

### DIFF
--- a/scripts/5_db_backup.sh
+++ b/scripts/5_db_backup.sh
@@ -10,6 +10,9 @@ CURRENT_VERSION=$(get_config CURRENT_VERSION)
 
 DB_ENGINE=$(get_config DB_ENGINE "mysql")
 DB_HOST=$(get_config DB_HOST)
+DB_PORT=$(get_config DB_PORT)
+DB_USER=$(get_config DB_USER)
+DB_PASSWORD=$(get_config DB_PASSWORD)
 DB_NAME=$(get_config DB_NAME)
 
 function main() {
@@ -35,11 +38,11 @@ function main() {
   case "${DB_ENGINE}" in
     mysql)
       DB_FILE=${BACKUP_DIR}/${DB_NAME}-${CURRENT_VERSION}-$(date +%F_%T).sql
-      backup_cmd='mysqldump --skip-add-locks --skip-lock-tables --single-transaction -h$DB_HOST -P$DB_PORT -u$DB_USER -p"$DB_PASSWORD" $DB_NAME > '${DB_FILE}
+      backup_cmd='mysqldump --skip-add-locks --skip-lock-tables --single-transaction -h"${DB_HOST}" -P"${DB_PORT}" -u"${DB_USER}" -p"${DB_PASSWORD}" "${DB_NAME}" > "${DB_FILE}"'
       ;;
     postgresql)
       DB_FILE=${BACKUP_DIR}/${DB_NAME}-${CURRENT_VERSION}-$(date +%F_%T).dump
-      backup_cmd='PGPASSWORD=${DB_PASSWORD} pg_dump --format=custom --no-owner -U $DB_USER -h $DB_HOST -p $DB_PORT -d "$DB_NAME" -f '${DB_FILE}
+      backup_cmd='PGPASSWORD="${DB_PASSWORD}" pg_dump --format=custom --no-owner -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}" -f "${DB_FILE}"'
       ;;
     *)
       log_error "$(gettext 'Invalid DB Engine selection')!"
@@ -47,8 +50,11 @@ function main() {
       ;;
   esac
 
-  if ! docker run --rm --env-file=${CONFIG_FILE} -i --network=jms_net -v "${BACKUP_DIR}:${BACKUP_DIR}" "${db_images}" bash -c "${backup_cmd}"; then
-    log_error "$(gettext 'Backup failed')!"
+  if ! docker run --rm \
+    --env DB_HOST="${DB_HOST}" --env DB_PORT="${DB_PORT}" --env DB_USER="${DB_USER}" --env DB_PASSWORD="${DB_PASSWORD}" --env DB_NAME="${DB_NAME}" --env DB_FILE="${DB_FILE}" \
+    -i --network=jms_net \
+    -v "${BACKUP_DIR}:${BACKUP_DIR}" \
+    "${db_images}" bash -c "${backup_cmd}"; then
     log_error "$(gettext 'Backup failed')!"
     rm -f "${DB_FILE}"
     exit 1


### PR DESCRIPTION
This PR addresses a security vulnerability in the database backup and restore scripts, as reported by our Russian distributor AFI.

Problem
The original implementation directly interpolated user-controlled configuration values into shell commands without proper sanitization. This could allow attackers who have write access to configuration files to inject arbitrary commands.

Example of vulnerable code:

`backup_cmd='mysqldump ... $DB_NAME > '${DB_FILE}`

If an attacker sets DB_NAME=jumpserver; rm -rf / in the config file, it would result in:

`mysqldump ... jumpserver; rm -rf / > backup.sql`

Possible solutions:
1. Modified Docker command to explicitly pass environment variables with values
2. Changed from --env DB_NAME to --env DB_NAME="${DB_NAME}"

If that is acceptable, please review this PR, and apply the same security improvements to the restore_db script for consistency.
